### PR TITLE
Allow plat_Highlight() to distinguish between moving a piece and showing attackers/defenders.

### DIFF
--- a/src/c64/plat64.c
+++ b/src/c64/plat64.c
@@ -362,7 +362,7 @@ void plat_ShowSideToGoLabel(char side)
 }
 
 /*-----------------------------------------------------------------------*/
-void plat_Highlight(char position, char color)
+void plat_Highlight(char position, char color, char)
 {
 	char y = position / 8, x = position & 7;
 	

--- a/src/human.c
+++ b/src/human.c
@@ -94,7 +94,7 @@ void human_ProcessToggle(int keyMask, char side, char tile)
 			{
 				attacker = gpAttackBoard[offset+i];
 				if(gShowAttacks[side] & SET_BIT(attack))
-					plat_Highlight(attacker,2+attack);
+					plat_Highlight(attacker,2+attack,0);
 				else
 					plat_DrawSquare(attacker);
 			}
@@ -136,11 +136,11 @@ char human_Play(char side)
 				// If a piece is selected, see if the second tile, under the cursor, is
 				// a valid move-to tile
 				validMove = board_findInList(gPossibleMoves, gNumMoves, gTile[1]);
-				plat_Highlight(gTile[1], validMove ? HCOLOR_ATTACK : HCOLOR_INVALID);
+				plat_Highlight(gTile[1], validMove ? HCOLOR_ATTACK : HCOLOR_INVALID,1);
 			}
 
 			// Show the cursor
-			plat_Highlight(gTile[0], selector ? HCOLOR_SELECTED : NONE == gPiece[0] || gColor[0] != side ? HCOLOR_EMPTY : gNumMoves ? HCOLOR_VALID : HCOLOR_INVALID);
+			plat_Highlight(gTile[0], selector ? HCOLOR_SELECTED : NONE == gPiece[0] || gColor[0] != side ? HCOLOR_EMPTY : gNumMoves ? HCOLOR_VALID : HCOLOR_INVALID,1);
 		}
 
 		// If the cursor moved and the toggle-show-attackers/defenders states were on for this side,

--- a/src/plat.h
+++ b/src/plat.h
@@ -15,7 +15,7 @@ char plat_Menu(char **menuItems, char height, char *scroller);
 void plat_DrawBoard(char clearLog);
 void plat_DrawSquare(char position);
 void plat_ShowSideToGoLabel(char side);
-void plat_Highlight(char position, char color);
+void plat_Highlight(char position, char color, char cursor);
 void plat_ShowMessage(char *str, char color);
 void plat_ClearMessage();
 void plat_AddToLogWin();

--- a/src/term/platTerm.c
+++ b/src/term/platTerm.c
@@ -242,12 +242,12 @@ void plat_ShowSideToGoLabel(char side)
 }
 
 /*-----------------------------------------------------------------------*/
-void plat_Highlight(char position, char color)
+void plat_Highlight(char position, char color, char cursor)
 {
 	char y = (BOARD_PIECE_HEIGHT/2)+1+BOARD_PIECE_HEIGHT*((position / 8)), x = (BOARD_PIECE_WIDTH/2)+BOARD_PIECE_WIDTH*((position & 7));
 	move(y,x);
 	color_set(color,0);
-	printw("*");
+	printw(cursor?"*":"!");
 }
 
 /*-----------------------------------------------------------------------*/


### PR DESCRIPTION
Notes:
- The color isn't usable for this distinction as HCOLOR_ATTACK is used for both scenarios.
- This change doesn't make use of the new distinction on the C64. One option would be to use different brackets for the two scenarios.