### PR TITLE
Replaced cmd file with Makefile for creating disk image.

### DIFF
--- a/Makefile-dsk.mk
+++ b/Makefile-dsk.mk
@@ -1,0 +1,14 @@
+DSK = cc65-Chess.dsk
+
+# For this one, see https://applecommander.github.io/
+AC ?= ac.jar
+
+REMOVES += $(DSK)
+
+.PHONY: dsk
+dsk: $(DSK)
+
+$(DSK): cc65-Chess.apple2
+	copy apple2\template.dsk $@
+	java -jar $(AC) -p  $@ chess.system sys < $(shell cl65 --print-target-path)\apple2\util\loader.system
+	java -jar $(AC) -as $@ chess        bin < cc65-Chess.apple2

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,0 @@
-copy apple2\template.dsk cc65-Chess.dsk
-java -jar apple2\AppleCommander-win64-1.5.0.jar -p  cc65-Chess.dsk chess.system sys < \cc65\target\apple2\util\loader.system
-java -jar apple2\AppleCommander-win64-1.5.0.jar -as cc65-Chess.dsk chess        bin < cc65-Chess.apple2


### PR DESCRIPTION
- Only works on Windows
- Requires the variable AC to be set either as env var, on the make cmdline or in the main Makefile