### PR TITLE
Apple2: follow cc65 updates

### DIFF
--- a/src/apple2/hires.s
+++ b/src/apple2/hires.s
@@ -12,9 +12,7 @@
 .include "apple2.inc"
 .include "zeropage.inc"
 
-.import popa, popax
-
-VERSION := $FBB3
+.import popa, popax, _videomode, _allow_lowercase
 
 
 .rodata
@@ -41,16 +39,11 @@ _hires_Pieces:
 
 .proc   _hires_Init
 
-        bit     $C082       ; Switch in ROM
-
-        lda     VERSION     ; Needs ROM
-        cmp     #$06        ; Apple //e ?
-        bne     :+
-
         lda     #$15        ; Turn off 80-column firmware
-        jsr     $C300       ; Needs ROM (see $CEF4)
+        jsr     _videomode
 
-:       bit     $C080       ; Back to LC bank 2 for R/O
+        lda     #$00        ; Disable lowercase as we use revers()
+        jsr     _allow_lowercase
 
         bit     TXTCLR
         bit     MIXCLR


### PR DESCRIPTION
The apple2 cc65 runtime now handles videomode() and lowercase characters. Use it, and disable lowercase manually as we use revers() for the UI selection (The Apple II doesn't have inverse lowercase characters).